### PR TITLE
More binder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ venv.bak/
 
 # doit
 .doit*
+
+# yarn
+.yarn-links/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,5 @@ venv.bak/
 # mypy
 .mypy_cache/
 
-#doit
+# doit
 .doit*

--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,4 @@ venv.bak/
 .mypy_cache/
 
 #doit
-.doit.db*
+.doit*

--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,4 @@ venv.bak/
 node_modules/
 
 # repos
-jupyterlab/
-lumino/
+repos/

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ venv.bak/
 # yarn
 .yarn-links/
 node_modules/
+
+# repos
+jupyterlab/
+lumino/

--- a/dodo.py
+++ b/dodo.py
@@ -5,8 +5,10 @@ https://github.com/jupyterlab/lumino@09aec10
 # change the urls above to link different jupyter references.
 
 
+import os
 import pathlib
-import doit
+import doit.tools
+import json
 
 DOIT_CONFIG = {
     "backend": "sqlite3",
@@ -14,9 +16,23 @@ DOIT_CONFIG = {
     "par_type": "thread",
 }
 
+os.environ.update(
+    PYTHONUNBUFFERED="1",
+    PYTHONIOENCODING="utf-8",
+    PIP_NO_DEPS="1",
+    PIP_NO_BUILD_ISOLATION="1",
+    PIP_DISABLE_PIP_VERSION_CHECK="1",
+    PIP_IGNORE_INSTALLED="1"
+)
+
 HERE = pathlib.Path(__file__).parent
 
-repos = list(filter(bool, __doc__.splitlines()))
+# don't pollute the global state
+LINKS = (HERE / ".yarn-links").resolve()
+YARN = ["yarn", "--link-folder", LINKS]
+PIP = ["python", "-m", "pip"]
+
+URLS = list(filter(bool, __doc__.splitlines()))
 
 
 def task_lint():
@@ -31,62 +47,82 @@ def task_lint():
 # add targets to the docstring to include in the dev build.
 def task_clone():
     """clone all the repos defined in the doc string"""
-    for repo in repos:
-        repo, _, branch = repo.rpartition("@")
-        path = pathlib.Path(repo.rpartition("/")[2])
+    for url in URLS:
+        path = url_to_path(url)
         yield dict(
-            name=f"clone_{repo}",
-            actions=[] if path.exists() else [f"git clone --depth 1 {repo}"],
+            name=path.name,
+            actions=[] if path.exists() else [do("git", "clone", "--depth=1", url)],
             targets=[path / "package.json"]
         )
 
-def task_build():
+
+def task_setup():
     """ensure a working build of live development builds"""
-    for dep in [repo_to_path(x) / "package.json" for x in repos]:
+    for repo in map(url_to_path, URLS):
         yield dict(
-            name=f"install_{dep}",
-            file_dep=[dep],
-            actions=[
-                f"""cd {dep.parent} && jlpm --prefer-offline --ignore-optional"""
-            ],
-            targets=[dep.parent / "node_modules/.yarn-integrity"]
-        )
-        yield dict(
-            name=f"build_{dep}",
-            file_dep=[dep.parent / "node_modules/.yarn-integrity"],
-            actions=[
-                f"""cd {dep.parent} && jlpm build"""
-            ],
-            targets=list(dep.parent.rglob("packages/*/lib/*.js"))
+            name=f"{repo.name}:yarn",
+            file_dep=[repo / "package.json"],
+            actions=[do(*YARN, cwd=repo)],
+            targets=yarn_integrity(repo)
         )
 
-def task_link_lumino():
-    """jupter labextension link changes across the repos"""
-    # find the changes in the repos relative to master.
+        setup_py = repo / "setup.py"
+
+        if setup_py.exists():
+            yield dict(
+                name=f"{repo.name}:pip",
+                file_dep=yarn_integrity(repo),
+                actions=[
+                    do(*PIP, "uninstall", "-y", repo.name, cwd=repo),
+                    do(*PIP, "install", "-e", ".", cwd=repo),
+                    do(*PIP, "check")
+                ]
+            )
+
+        yield dict(
+            name=f"{repo.name}:build",
+            file_dep=yarn_integrity(repo),
+            actions=[
+                do(*YARN, "build", cwd=repo)
+            ],
+            targets=list(repo.glob("packages/*/lib/*.js")),
+            **(
+                dict(task_dep=[f"setup:{repo.name}:pip"]) if setup_py.exists() else {}
+            )
+        )
+
+
+def task_link():
+    """link yarn packages across the repos"""
     # go to the direction and links the packages.
-    for pkg in pathlib.Path("lumino/packages").glob("*/package.json"):
+    lumino = [url_to_path(u) for u in URLS if "jupyterlab/lumino" in u][0]
+    lab = [url_to_path(u) for u in URLS if "jupyterlab/jupyterlab" in u][0]
+
+    for pkg_json in lumino.glob("packages/*/package.json"):
+        pkg = pkg_json.parent
+        pkg_data = json.loads(pkg_json.read_text(encoding="utf-8"))
+        pkg_name = pkg_data["name"]
+        out_link = LINKS / pkg_data["name"] / "package.json"
+        in_link = lab / f"node_modules/{pkg_name}/package.json"
         yield dict(
-            name=f"link_lumino_{pkg.parent.name}",
-            file_dep=[
-                pkg,
-                pkg.parent.parent.parent / "node_modules/.yarn-integrity"
+            name=pkg_name,
+            file_dep=[*yarn_integrity(lumino), *yarn_integrity(lab), pkg_json],
+            actions=[
+                (doit.tools.create_folder, [LINKS]),
+                do(*YARN, "link", cwd=pkg)
             ],
-            actions=f"""
-                cd lumino/packages/{pkg.parent.name} \
-                && jlpm link
-
-                """.strip().splitlines(),#&& touch ../../build/link.lumino.{pkg.parent.name}.ok
-            targets=[]# [f"build/link.lumino.{pkg.parent.name}.ok"]
+            targets=[out_link]
         )
-        yield dict(
-            name=f"link_lab_{pkg.parent.name}",
-            file_dep=[],#[f"build/link.lumino.{pkg.parent.name}.ok"],
-            actions=f"""
-                cd jupyterlab \
-                && jlpm link @lumino/{pkg.parent.name}
 
-                """.strip().splitlines(), #&& touch ../build/link.lab.{pkg.parent.name}.ok
-            targets=[f"build/link.lab.{pkg.parent.name}.ok"]
+        yield dict(
+            name=f"lab:{pkg_name}",
+            uptodate=[doit.tools.config_changed({
+                pkg_name: (
+                    in_link.exists() and in_link.resolve() == pkg_json.resolve()
+                )
+            })],
+            file_dep=[out_link],
+            actions=[do(*YARN, "link", pkg_name, cwd=lab)]
         )
 
 def task_config():
@@ -110,6 +146,14 @@ def task_config():
 
 # utilities
 
-def repo_to_path(x):
+def url_to_path(x):
     """extract the local checkout name"""
     return pathlib.Path(x.rpartition("@")[0].rpartition("/")[2])
+
+def do(*args, cwd=HERE, **kwargs):
+    """wrap a CmdAction for consistency"""
+    return doit.tools.CmdAction(list(args), shell=False, cwd=str(pathlib.Path(cwd)))
+
+def yarn_integrity(repo):
+    """the file created after yarn install"""
+    return [repo / "node_modules/.yarn-integrity"]

--- a/dodo.py
+++ b/dodo.py
@@ -5,20 +5,28 @@ https://github.com/jupyterlab/lumino@09aec10
 # change the urls above to link different jupyter references.
 
 
+import pathlib
+import doit
+
 DOIT_CONFIG = {
     "backend": "sqlite3",
     "verbosity": 2,
     "par_type": "thread",
 }
 
+HERE = pathlib.Path(__file__).parent
 
-import pathlib
-import doit
 repos = list(filter(bool, __doc__.splitlines()))
 
-def repo_to_path(x):
-    """extract the local checkout name"""
-    return pathlib.Path(x.rpartition("@")[0].rpartition("/")[2])
+
+def task_lint():
+    all_py = HERE.glob("*.py")
+    yield dict(
+        name="py",
+        file_dep=[*all_py],
+        actions=[["black", "--silent", *all_py]]
+    )
+
 
 # add targets to the docstring to include in the dev build.
 def task_clone():
@@ -35,7 +43,6 @@ def task_clone():
 def task_build():
     """ensure a working build of live development builds"""
     for dep in [repo_to_path(x) / "package.json" for x in repos]:
-        print(dep)
         yield dict(
             name=f"install_{dep}",
             file_dep=[dep],
@@ -100,3 +107,9 @@ def task_config():
 #                     doit.CmdAction([], shell=False, cwd=postBuild.parent)
 #                 ]
 #             )
+
+# utilities
+
+def repo_to_path(x):
+    """extract the local checkout name"""
+    return pathlib.Path(x.rpartition("@")[0].rpartition("/")[2])

--- a/dodo.py
+++ b/dodo.py
@@ -4,6 +4,14 @@ https://github.com/jupyterlab/lumino@09aec10
 """
 # change the urls above to link different jupyter references.
 
+
+DOIT_CONFIG = {
+    "backend": "sqlite3",
+    "verbosity": 2,
+    "par_type": "thread",
+}
+
+
 import pathlib
 import doit
 repos = list(filter(bool, __doc__.splitlines()))
@@ -33,7 +41,7 @@ def task_build():
             file_dep=[dep],
             actions=[
                 f"""cd {dep.parent} && jlpm --prefer-offline --ignore-optional"""
-            ], 
+            ],
             targets=[dep.parent / "node_modules/.yarn-integrity"]
         )
         yield dict(
@@ -41,7 +49,7 @@ def task_build():
             file_dep=[dep.parent / "node_modules/.yarn-integrity"],
             actions=[
                 f"""cd {dep.parent} && jlpm build"""
-            ], 
+            ],
             targets=list(dep.parent.rglob("packages/*/lib/*.js"))
         )
 
@@ -53,23 +61,23 @@ def task_link_lumino():
         yield dict(
             name=f"link_lumino_{pkg.parent.name}",
             file_dep=[
-                pkg, 
+                pkg,
                 pkg.parent.parent.parent / "node_modules/.yarn-integrity"
-            ],         
+            ],
             actions=f"""
                 cd lumino/packages/{pkg.parent.name} \
-                && jlpm link 
-                
+                && jlpm link
+
                 """.strip().splitlines(),#&& touch ../../build/link.lumino.{pkg.parent.name}.ok
             targets=[]# [f"build/link.lumino.{pkg.parent.name}.ok"]
         )
         yield dict(
             name=f"link_lab_{pkg.parent.name}",
-            file_dep=[],#[f"build/link.lumino.{pkg.parent.name}.ok"],         
+            file_dep=[],#[f"build/link.lumino.{pkg.parent.name}.ok"],
             actions=f"""
                 cd jupyterlab \
-                && jlpm link @lumino/{pkg.parent.name} 
-                
+                && jlpm link @lumino/{pkg.parent.name}
+
                 """.strip().splitlines(), #&& touch ../build/link.lab.{pkg.parent.name}.ok
             targets=[f"build/link.lab.{pkg.parent.name}.ok"]
         )

--- a/dodo.py
+++ b/dodo.py
@@ -24,7 +24,7 @@ def task_lint():
     yield dict(
         name="py",
         file_dep=[*all_py],
-        actions=[["black", "--silent", *all_py]]
+        actions=[["black", "--quiet", *all_py]]
     )
 
 

--- a/dodo.py
+++ b/dodo.py
@@ -189,7 +189,7 @@ def task_app():
                 [],
             ),
         ],
-        actions=[do(*YARN, "build:prod", cwd=dev_mode)],
+        actions=[do(*YARN, "build", cwd=dev_mode)],
         targets=[dev_index],
     )
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - numpy
   - pip
   - python>=3.7,<3.10
+  - pyyaml
   - twine
   - vega_datasets
   - wheel

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - git
   - jupyter_server
   - jupyter-packaging
-  - jupyter-server-proxy
   - jupyterlab_server
   - matplotlib-base
   - nbclassic

--- a/environment.yml
+++ b/environment.yml
@@ -2,18 +2,18 @@
 # across different development versions.
 name: a11y
 channels:
-- conda-forge
-- nodefaults
+  - conda-forge
+  - nodefaults
 dependencies:
-- nodejs>=12,<15,!=13.*
-- python>=3.7,<3.10
-- jupyter-server-proxy
-- matplotlib-base
-- numpy
-- pip
-- vega_datasets
-- xeus-python
-- yarn<2
-- doit
-- pip
-- pip: {}
+  - black
+  - doit
+  - git
+  - jupyter-server-proxy
+  - matplotlib-base
+  - nodejs>=12,<15,!=13.*
+  - numpy
+  - pip
+  - python>=3.7,<3.10
+  - vega_datasets
+  - xeus-python
+  - yarn<2

--- a/environment.yml
+++ b/environment.yml
@@ -8,12 +8,18 @@ dependencies:
   - black
   - doit
   - git
+  - jupyter_server
+  - jupyter-packaging
   - jupyter-server-proxy
+  - jupyterlab_server
   - matplotlib-base
+  - nbclassic
   - nodejs>=12,<15,!=13.*
   - numpy
   - pip
   - python>=3.7,<3.10
+  - twine
   - vega_datasets
+  - wheel
   - xeus-python
   - yarn<2

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 import nox
+
+
 @nox.session(venv_backend="conda")
 def build(session):
     session.install("doit")
     session.run("doit", *session.posargs)
-

--- a/postBuild
+++ b/postBuild
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 doit list --all --status
 
-doit || doit || doit
+time doit clone | tee doit.clone.log
+time doit setup | tee doit.setup.log
+time doit link | tee doit.link.log
+time doit app | tee doit.app.log
 
 doit list --all --status

--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 doit list --all --status
 
-doit
+doit || doit || doit
 
-cd jupyterlab && pip install -e . && jlpm && jlpm build
+doit list --all --status

--- a/postBuild
+++ b/postBuild
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 doit list --all --status
 
-time doit clone | tee doit.clone.log
-time doit setup | tee doit.setup.log
-time doit link | tee doit.link.log
-time doit app | tee doit.app.log
+time doit clone |& tee doit.clone.log
+time doit setup |& tee doit.setup.log
+time doit link |& tee doit.link.log
+time doit app |& tee doit.app.log
 
 doit list --all --status

--- a/repos.yml
+++ b/repos.yml
@@ -1,0 +1,10 @@
+# these are some repos we want to check out and test against:
+repos:
+  jupyterlab:
+    origin: https://github.com/jupyterlab/jupyterlab
+    ref: pull/9622/head
+    commit: "408f30f"
+  lumino:
+    origin: https://github.com/jupyterlab/lumino
+    ref: pull/149/head
+    commit: "09aec10"

--- a/repos.yml
+++ b/repos.yml
@@ -1,10 +1,19 @@
-# these are some repos we want to check out and test against:
+# these are some repos we want to check out and test against.
+# these aren't submodules, so that they can be easily updated from the web UI
 repos:
+  # a local symbolic name, also where packages will be checked out in `packages`
   jupyterlab:
+    # the public remote from which to start
     origin: https://github.com/jupyterlab/jupyterlab
-    ref: pull/9622/head
-    commit: "408f30f"
+    # an ordered list of refs to attempt merging: must be fast-forward
+    refs:
+      - # the upstream ref, found with `git ls-remote`
+        ref: pull/9622/head
+        # the specific committish, available in the ref
+        commit: "408f30f"
+
   lumino:
     origin: https://github.com/jupyterlab/lumino
-    ref: pull/149/head
-    commit: "09aec10"
+    refs:
+      - ref: pull/149/head
+        commit: "09aec10"


### PR DESCRIPTION
https://gke2.mybinder.org/v2/gh/bollwyvl/accessibility/more-binder?urlpath=lab

- [x] moves the repo specification to another yaml file
  -  can't tell, but don't think the commits were checking out properly
- [x] reworks entropy with a custom `.yarn-links` folder that doesn't break my local stuff :blush: 
- [x] clobbers the main `$PREFIX/share/jupyter/lab` with stuff from `./jupyterlab/dev_mode`
  - gives a shorter binder url... and means binder's "stock" federated extensions will load (e.g. widgets, offlineonotebook)
  - obviates need for custom `start`
- [x] runs `black`

Trying to merge the current upstream HEAD was a bridge too far, and didn't work... but the machinery is there to do octopus-style merges, if they are all fast-forward. Behavior is somewhat undefined if the merges don't work.

As for validation, based on the two commits:
- the checkable command palette items have `aria-checked` set
- the sidebars don't say `main sidebar navigation`

So i think it's pulling stuff in, properly. 